### PR TITLE
dom: Add new function to set all types of MB React inputs

### DIFF
--- a/dom/react.js
+++ b/dom/react.js
@@ -26,15 +26,16 @@ export function setReactTextareaValue(input, value) {
 	input.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
-// MB React input logics often requires: input event, update value, then change event
-// https://github.com/jesus2099/konami-command/blob/a94c502bd7d5f4f4e29c91c7ac2a52881c96821e/lib/SUPER.js#L163-L171
-
 /**
- * Sets the value of an input/select/textarea element which has been manipulated by React.
+ * Sets the value of a MusicBrainz input/select/textarea element which has been manipulated by React.
+ *
+ * MB React input logics often requires: input event, update value, then change event
+ *
  * @param {HTMLInputElement|HTMLSelectElement|HTMLTextAreaElement} input
  * @param {string} value
+ * @see https://github.com/jesus2099/konami-command/blob/a94c502bd7d5f4f4e29c91c7ac2a52881c96821e/lib/SUPER.js#L163-L171
  */
-export function setReactInputSelectTextareaValue(input, value) {
+export function setMBReactInputValue(input, value) {
 	input.dispatchEvent(new Event('input', { bubbles: true }));
 	(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(input), 'value').set).call(input, value);
 	input.dispatchEvent(new Event('change', { bubbles: true }));

--- a/dom/react.js
+++ b/dom/react.js
@@ -4,6 +4,7 @@ const nativeInputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.
 
 /**
  * Sets the value of an input element which has been manipulated by React.
+ * Deprecated: Use setReactInputSelectTextareaValue instead
  * @param {HTMLInputElement} input 
  * @param {string} value 
  */
@@ -16,10 +17,25 @@ const nativeTextareaValueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaEl
 
 /**
  * Sets the value of a textarea input element which has been manipulated by React.
+ * Deprecated: Use setReactInputSelectTextareaValue instead
  * @param {HTMLTextAreaElement} input 
  * @param {string} value 
  */
 export function setReactTextareaValue(input, value) {
 	nativeTextareaValueSetter.call(input, value);
 	input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+// MB React input logics often requires: input event, update value, then change event
+// https://github.com/jesus2099/konami-command/blob/a94c502bd7d5f4f4e29c91c7ac2a52881c96821e/lib/SUPER.js#L163-L171
+
+/**
+ * Sets the value of an input/select/textarea element which has been manipulated by React.
+ * @param {HTMLInputElement|HTMLSelectElement|HTMLTextAreaElement} input
+ * @param {string} value
+ */
+export function setReactInputSelectTextareaValue(input, value) {
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+	(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(input), 'value').set).call(input, value);
+	input.dispatchEvent(new Event('change', { bubbles: true }));
 }

--- a/dom/react.js
+++ b/dom/react.js
@@ -4,7 +4,6 @@ const nativeInputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.
 
 /**
  * Sets the value of an input element which has been manipulated by React.
- * Deprecated: Use setReactInputSelectTextareaValue instead
  * @param {HTMLInputElement} input 
  * @param {string} value 
  */
@@ -17,7 +16,6 @@ const nativeTextareaValueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaEl
 
 /**
  * Sets the value of a textarea input element which has been manipulated by React.
- * Deprecated: Use setReactInputSelectTextareaValue instead
  * @param {HTMLTextAreaElement} input 
  * @param {string} value 
  */


### PR DESCRIPTION
Required for https://github.com/kellnerd/musicbrainz-scripts/pull/49

Handles all types of form inputs (input, select, textarea).

Handles MB React input logics that often requires:

1. input event
2. update value
3. then change event